### PR TITLE
This fix is to avoid NPE when running: grails prod build-standalone file.jar

### DIFF
--- a/scripts/BuildStandalone.groovy
+++ b/scripts/BuildStandalone.groovy
@@ -92,7 +92,7 @@ buildJar = { File workDir, File jar, File warfile = null ->
 	          source: '1.5',
 	          target: '1.5'
 
-	jar.parentFile.mkdirs()
+	jar.canonicalFile.parentFile.mkdirs()
 	ant.jar(destfile: jar) {
 		fileset dir: workDir
 		if (warfile) {


### PR DESCRIPTION
This fix is to avoid NPE when running: `grails prod build-standalone file.jar`

| Error Error executing script BuildStandalone: java.lang.NullPointerException: Cannot invoke method mkdirs() on null object (Use --stacktrace to see the full trace)
