### PR TITLE
Add useJetty configuration option to change default server.

### DIFF
--- a/scripts/BuildStandalone.groovy
+++ b/scripts/BuildStandalone.groovy
@@ -48,7 +48,8 @@ target(buildStandalone: 'Build a standalone app with embedded server') {
 		String jarname = argsMap.params[0]
 		File jar = jarname ? new File(jarname).absoluteFile : new File(workDir.parentFile, 'standalone-' + grailsAppVersion + '.jar').absoluteFile
 
-		boolean jetty = argsMap.jetty
+    boolean jetty = (argsMap.jetty || config.grails.plugins.standalone.useJetty) && !argsMap.tomcat
+
 
 		event 'StatusUpdate', ["Building standalone jar $jar.path for ${jetty ? 'Jetty' : 'Tomcat'}"]
 

--- a/src/docs/guide/2 Running the application.gdoc
+++ b/src/docs/guide/2 Running the application.gdoc
@@ -24,6 +24,20 @@ or
 grails -Dgrails.env=demo build-standalone our_cool_demo.jar --jetty
 {code}
 
+You can also change the default embedded server to Jetty by placing the
+following in your Config.groovy:
+
+{code}
+grails.plugins.standalone.useJetty = true
+{/code}
+
+If you've set jetty to the default, you can force a tomcat build later with the \-\-tomcat flag:
+
+{code:java}
+grails build-standalone --tomcat
+{/code}
+
+
 h4. Running the server
 
 As long as the target machine has Java 5 or higher available, all you need to do next is run


### PR DESCRIPTION
We are using the standalone plugin as a dependency for another build related
plugin which packages the grails application as an RPM.  My plugin calls
buildStandalone() within it's own GANT task.  Since the standalone plugin
relies completely on command line arguments to change the server, it makes using
Jetty instead of Tomcat very difficult in this manner.

By adding the configuration option, we gain the necessary flexibility without
losing any current functionality.  A user can now use the following config
option to make Jetty the default:

grails.plugins.standalone.useJetty = true

A complementary flag is being added as well, which will allow you to override
the Jetty default in the same manner you would override the Tomcat default:

grails build-standalone --tomcat
