### PR TITLE
Ability to specify custom main class

### DIFF
--- a/scripts/BuildStandalone.groovy
+++ b/scripts/BuildStandalone.groovy
@@ -134,7 +134,7 @@ buildJar = { File workDir, File jar, boolean jetty, File warfile = null ->
 			zipfileset file: warfile, fullpath: 'embedded.war'
 		}
 		manifest {
-			attribute name: 'Main-Class', value: jetty ? 'grails.plugin.standalone.JettyLauncher' : 'grails.plugin.standalone.Launcher'
+			attribute name: 'Main-Class', value: resolveMainClass(jetty)
 		}
 	}
 
@@ -195,6 +195,14 @@ resolveJars = { boolean jetty, standaloneConfig ->
 	}
 
 	paths
+}
+
+String resolveMainClass(boolean jetty) {
+    if (buildSettings.config.grails.plugin.standalone.mainClass) {
+        buildSettings.config.grails.plugin.standalone.mainClass
+    } else {
+        jetty ? 'grails.plugin.standalone.JettyLauncher' : 'grails.plugin.standalone.Launcher'
+    }
 }
 
 calculateJettyDependencies = { standaloneConfig ->

--- a/src/docs/guide/2 Running the application.gdoc
+++ b/src/docs/guide/2 Running the application.gdoc
@@ -50,6 +50,7 @@ grails.plugin.standalone. jettyVersion | '7.6.0.v20120127' | the version of Jett
 grails.plugin.standalone. tomcatVersion | '7.0.39' | the version of Tomcat to use
 grails.plugin.standalone. tomcatDependencies | 'tomcat-annotations-api', 'tomcat-api', 'tomcat-catalina-ant', 'tomcat-catalina', 'tomcat-coyote', 'tomcat-juli', 'tomcat-servlet-api', 'tomcat-util' | the Tomcat jars to use
 grails.plugin.standalone. tomcatEmbedDependencies | 'tomcat-embed-core', 'tomcat-embed-jasper', 'tomcat-embed-logging-juli', 'tomcat-embed-logging-log4j' | the Tomcat embed jars to use
+grails.plugin.standalone. mainClass | none | Optionally specify a custom main class to include in the MANIFEST.MF. Note that you will then be required to call either grails.plugin.standalone.JettyLauncher or grails.plugin.standalone.Launcher yourself
 {table}
 
 h3. Running the server


### PR DESCRIPTION
I've added the ability to specify a custom main class for the MANIFEST.MF, via a new configuration property "grails.plugin.standalone.mainClass". This would be very handy for users that want to perform their own boostrapping of the environment before invoking Tomcat/Jetty. My use case is to read in HTTP/SSL properties from a config.yml, similar to how Dropwizard works, to then pass to Jetty/Tomcat.

I tried to write a unit test for it, but it seems that unit testing gant scripts isn't possible within grails currently. I have manually tested each of the 3 use cases though.

I've also updated the documentation accordingly.
