### PR TITLE
Allow configuring jarname via BuildConfig.groovy

### DIFF
--- a/scripts/BuildStandalone.groovy
+++ b/scripts/BuildStandalone.groovy
@@ -45,7 +45,7 @@ target(buildStandalone: 'Build a standalone app with embedded server') {
 			return
 		}
 
-		String jarname = argsMap.params[0]
+		String jarname = argsMap.params[0] ?: buildSettings.config.grails.plugin.standalone.jarname
 		File jar = jarname ? new File(jarname).absoluteFile : new File(workDir.parentFile, 'standalone-' + grailsAppVersion + '.jar').absoluteFile
 
 		boolean jetty = (argsMap.jetty || buildSettings.config.grails.plugin.standalone.useJetty) && !argsMap.tomcat


### PR DESCRIPTION
Enables the configuration of the name of the generated jar file via BuildConfig.groovy.
It is possible to write the following in BuildConfig.groovy:
_grails.plugin.standalone.jarname = "target/${appName}-standalone-${appVersion}.jar"_
