### PR TITLE
added two runtime configuration options to allow for usage in common production-ready setup.

### DIFF
--- a/src/docs/guide/running.gdoc
+++ b/src/docs/guide/running.gdoc
@@ -76,6 +76,8 @@ There are several arguments you can pass to customize how the application runs, 
 # @compressableMimeTypes@, a comma separated list of MIME types for which HTTP compression may be used; defaults to the Tomcat defaults, @"text/html,text/xml,text/plain"@
 # @sessionTimeout@, the session timeout in minutes; defaults to 30
 # @nio@ or @tomcat.nio@, whether to use NIO; defaults to true
+# @serverName@, a specific value to use as HTTP Server Header, by default tomcat will use Apache-Coyote/1.1 if none set at application level (Tomcat only)
+# @enableProxySupport@, enables support for X-Forwarded headers by adding a pre-configured RemoteIpValve, defaults to false (Tomcat only)
 
 In addition, if you specify a value that is the name of a system property (e.g. 'home.dir'), the system property value will be used.
 

--- a/src/java/grails/plugin/standalone/AbstractLauncher.java
+++ b/src/java/grails/plugin/standalone/AbstractLauncher.java
@@ -44,7 +44,8 @@ public abstract class AbstractLauncher {
 			"context", "host", "port", "httpsPort", "keystorePath", "javax.net.ssl.keyStore",
 			"keystorePassword", "javax.net.ssl.keyStorePassword", "truststorePath", "javax.net.ssl.trustStore",
 			"trustStorePassword", "javax.net.ssl.trustStorePassword", "enableClientAuth", "workDir",
-			"enableCompression", "compressableMimeTypes", "sessionTimeout", "nio", "tomcat.nio");
+			"enableCompression", "compressableMimeTypes", "sessionTimeout", "nio", "tomcat.nio",
+			"serverName", "enableProxySupport");
 
 	protected Map<String, String> argsMap;
 


### PR DESCRIPTION
I'd like to include support for the following two options for tomcat with this pull request.

"serverName" to allow for overriding the default value of the http "Server" header (common hardening practice)

"enableProxySupport" to support running behind an (SSL terminating) reverse proxy/load balancer while still receiving the real client ip-address and scheme (http/https) used to connect to the proxy

Espescially the last option can be quite handy as its tricky to accomplish on application level.