### PR TITLE
Fix Missing RemoteIpValve import

### DIFF
--- a/src/runtime/grails/plugin/standalone/Launcher.java
+++ b/src/runtime/grails/plugin/standalone/Launcher.java
@@ -30,6 +30,7 @@ import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.StandardServer;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.CrawlerSessionManagerValve;
+import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.coyote.http11.Http11NioProtocol;
 
 /**


### PR DESCRIPTION
Doesn't compile without this import.
