### PR TITLE
Add option for disabling the killSwitch Port

### DIFF
--- a/src/docs/guide/running.gdoc
+++ b/src/docs/guide/running.gdoc
@@ -78,6 +78,7 @@ There are several arguments you can pass to customize how the application runs, 
 # @nio@ or @tomcat.nio@, whether to use NIO; defaults to true
 # @serverName@, a specific value to use as HTTP Server Header, by default tomcat will use Apache-Coyote/1.1 if none set at application level (Tomcat only)
 # @enableProxySupport@, enables support for X-Forwarded headers by adding a pre-configured RemoteIpValve, defaults to false (Tomcat only)
+# @enableKillSwitch@, enables a listener on port+1 which will terminate tomcat upon receiving a request, defaults to true (Tomcat only)
 
 In addition, if you specify a value that is the name of a system property (e.g. 'home.dir'), the system property value will be used.
 

--- a/src/java/grails/plugin/standalone/AbstractLauncher.java
+++ b/src/java/grails/plugin/standalone/AbstractLauncher.java
@@ -45,7 +45,7 @@ public abstract class AbstractLauncher {
 			"keystorePassword", "javax.net.ssl.keyStorePassword", "truststorePath", "javax.net.ssl.trustStore",
 			"trustStorePassword", "javax.net.ssl.trustStorePassword", "enableClientAuth", "workDir",
 			"enableCompression", "compressableMimeTypes", "sessionTimeout", "nio", "tomcat.nio",
-			"serverName", "enableProxySupport");
+			"serverName", "enableProxySupport", "enableKillSwitch");
 
 	protected Map<String, String> argsMap;
 

--- a/src/runtime/grails/plugin/standalone/Launcher.java
+++ b/src/runtime/grails/plugin/standalone/Launcher.java
@@ -69,6 +69,7 @@ public class Launcher extends AbstractLauncher {
 	 *           <li>nio or tomcat.nio, defaults to true</li>
 	 *           <li>serverName, a specific value to use as HTTP Server Header, no default</li>
 	 *           <li>enableProxySupport, enables support for X-Forwarded headers, defaults to false</li>
+	 *           <li>enableKillSwitch, enables a listener on port+1 which will terminate tomcat upon receiving a request, defaults to true</li>
 	 *           </ul>
 	 *           In addition, if you specify a value that is the name of a system
 	 *           property (e.g. 'home.dir'), the system property value will be used.
@@ -137,8 +138,9 @@ public class Launcher extends AbstractLauncher {
 				enableClientAuth, truststorePath, trustStorePassword,
 				sessionTimeout, enableCompression, compressableMimeTypes, useNio,
 				serverName, enableProxySupport);
-
-		startKillSwitchThread(port);
+		
+		boolean enableKillSwitch = getBooleanArg("enableKillSwitch", true);
+		if (enableKillSwitch) {startKillSwitchThread(port);}
 		addShutdownHook();
 		addFailureLifecycleListener(contextPath);
 


### PR DESCRIPTION
Command line option "enableKillSwitch" defaults to true (matches existing behavior).
If `enableKillSwitch=false` the killSwitch port listener will not be bound.